### PR TITLE
Fix Writeback Index Prefix in Example Config

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -56,7 +56,7 @@ es_port: 9200
 # The index on es_host which is used for metadata storage
 # This can be a unmapped index, but it is recommended that you run
 # elastalert-create-index to set a mapping
-writeback_index: elastalert_status
+writeback_index: elastalert
 
 # If an alert fails for some reason, ElastAlert will retry
 # sending the alert until this time period has elapsed


### PR DESCRIPTION
Change writeback index prefix in `config.yaml.example` from `elastalert_status` to `elastalert` since we already attach appropriate suffixes in `create_index.py`